### PR TITLE
adding SOURCE_REPOSITORY argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,8 @@ module "build" {
     ADO_USER = data.aws_ssm_parameter.ado_user.value, 
     ADO_PASSWORD = data.aws_ssm_parameter.ado_password.value,
     TEST_REPORT = var.test_report_group,
-    CODE_COVERAGE_REPORT = var.coverage_report_group
+    CODE_COVERAGE_REPORT = var.coverage_report_group,
+    SOURCE_REPOSITORY = var.source_repository
   })
 }
 


### PR DESCRIPTION
Adding SOURCE_REPOSITORY to BUILD because not always the name of the Bitbucket repository will be the exact as application name.
Now must often I see that we're using APP_NAME in buildspecs but it's not always the case.
Because of that in order to keep the buildspec as generic as possible I want to add SOURCE_REPOSITORY to build.
BTW SOURCE_REPOSITORY already exist in main.tf and variables.tf it's just not in use.