### PR TITLE
adding source_repository argument to post deploy step

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,7 @@ module "post" {
     FROM_ENV = var.from_env,
     APP_NAME = var.app_name,
     ENV_TYPE = var.env_type,
-    ENABLE_JIRA_AUTOMATION = var.enable_jira_automation
+    ENABLE_JIRA_AUTOMATION = var.enable_jira_automation,
+    SOURCE_REPOSITORY = var.source_repository
     })
 }

--- a/templates/post_buildspec.yml.tpl
+++ b/templates/post_buildspec.yml.tpl
@@ -40,7 +40,7 @@ phases:
     commands:
       - |
         REPORT_URL="https://console.aws.amazon.com/codesuite/codedeploy/applications/ecs-deploy-${APP_NAME}-${ENV_NAME}/deployment-groups/ecs-deploy-group-${APP_NAME}-${ENV_NAME}"
-        URL="https://api.bitbucket.org/2.0/repositories/tolunaengineering/${APP_NAME}/commit/$COMMIT_ID/statuses/build/"
+        URL="https://api.bitbucket.org/2.0/repositories/${SOURCE_REPOSITORY}/commit/$COMMIT_ID/statuses/build/"
         curl --request POST --url $URL -u "$BB_USER:$BB_PASS" --header "Accept:application/json" --header "Content-Type:application/json" --data "{\"key\":\"${APP_NAME} Deploy\",\"state\":\"SUCCESSFUL\",\"description\":\"Deployment to ${ENV_NAME} succeeded\",\"url\":\"$REPORT_URL\"}"    
       - |
         if [ "${ENV_NAME}" == "prod" ] && [ "${ENABLE_JIRA_AUTOMATION}" == "true" ] ; then 


### PR DESCRIPTION
I've changed APP_NAME to SOURCE_REPOSITORY in requests to tolunaengineering because not always app_name == repository in bitbucket.
(we did such change 2 month ago for build step)